### PR TITLE
Add support for tooltips to prosemirror-menu

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -27,8 +27,19 @@ export class MenuItem {
         : null
     if (!dom) throw new RangeError("MenuItem without icon or label property")
     if (spec.title) {
-      const title = (typeof spec.title === "function" ? spec.title(view.state) : spec.title)
-      dom.setAttribute("title", translate(view, title))
+       let title = (typeof spec.title === "function" ? spec.title(view.state) : spec.title)
+
+       if (spec.shortcut) {
+          const modKey = navigator.userAgent.indexOf('Mac') > 0 ? '⌘' : 'ctrl';
+          const shortcut = spec.shortcut;
+          title = `${title} (${modKey}+${shortcut})`;
+       }
+
+       const tooltip = crel('div', {
+          'class': 'tooltiptext'
+       }, title);
+
+       dom.appendChild(tooltip);
     }
     if (spec.class) dom.classList.add(spec.class)
     if (spec.css) dom.style.cssText += spec.css

--- a/style/menu.css
+++ b/style/menu.css
@@ -1,3 +1,7 @@
+.prosemirror {
+   outline-style: none;
+}
+
 .ProseMirror-textblock-dropdown {
   min-width: 3em;
 }
@@ -46,7 +50,7 @@
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
   border-top: 4px solid currentColor;
-  opacity: .6;
+  color: rgba(0,0,0,.6);
   position: absolute;
   right: 4px;
   top: calc(50% - 2px);
@@ -84,7 +88,7 @@
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
   border-left: 4px solid currentColor;
-  opacity: .6;
+  color: rgba(0,0,0,.6);
   position: absolute;
   right: 4px;
   top: calc(50% - 4px);
@@ -108,7 +112,7 @@
 }
 
 .ProseMirror-menu-disabled {
-  opacity: .3;
+  color: rgba(0,0,0,.2);
 }
 
 .ProseMirror-menu-submenu-wrap:hover .ProseMirror-menu-submenu, .ProseMirror-menu-submenu-wrap-active .ProseMirror-menu-submenu {
@@ -129,6 +133,7 @@
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   overflow: visible;
+  outline-style: none;
 }
 
 .ProseMirror-icon {

--- a/style/menu.css
+++ b/style/menu.css
@@ -137,6 +137,45 @@
   vertical-align: -2px; /* Compensate for padding */
   padding: 2px 8px;
   cursor: pointer;
+  position: relative;
+}
+
+/* Tooltip text */
+.ProseMirror-icon .tooltiptext {
+    /* don't show the icon before hover */
+    opacity: 0;
+
+    /* stying etc */
+    background-color: black;
+    color: #fff;
+    text-align: center;
+    padding: 5px 0;
+    border-radius: 4px;
+    width: 180px;
+    font-size: 16px;
+    font-family: sans-serif;
+
+    /* Position the tooltip text */
+    position: absolute;
+    bottom: 120%;
+    left: 50%;
+    margin-left: -90px;
+}
+
+.ProseMirror-icon:hover .tooltiptext {
+    opacity: 1;
+    transition: opacity 0.2s .2s ease;
+}
+
+.ProseMirror-icon .tooltiptext::after { /* https://www.w3schools.com/css/css_tooltip.asp */
+    content: " ";
+    position: absolute;
+    top: 100%; /* At the bottom of the tooltip */
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: black transparent transparent transparent;
 }
 
 .ProseMirror-menu-disabled.ProseMirror-icon {


### PR DESCRIPTION
This pull changes the default functionality of how ProseMirror-menu
displays titles. Instead of setting the `title` attribute on the icon's
dom element, prosemirror-menu will now render a child div with the title
text and the keyboard shortcut specified in the menuspec.

There's also a couple small styling changes:
1) Prevents the focus highlighting that occurs when you click on the menubar
   - ![image](https://user-images.githubusercontent.com/6803522/41056217-4acaf72c-6978-11e8-972c-05364430de95.png)

2) Changes the `prosemirror-disabled` icons from opacity: 0.3 to color: rgba(0,0,0,0.2) to prevent the icons' children from inherting the opacity.
   - Note: I changed opacity 0.3 to rgba(0,0,0,0.2) because 0.3 looked too dark. Here's the icons with the rgba .2 styling:
![image](https://user-images.githubusercontent.com/6803522/41056165-1d547f70-6978-11e8-9315-796a798d41ae.png)
and the original:
![image](https://user-images.githubusercontent.com/6803522/41056099-ec781ede-6977-11e8-9fe7-772e38094b2a.png)

cr_req copperwall

CC @copperwall 
Closes #2 