### PR TITLE
Modify spacing and placement of tooltips

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -32,7 +32,7 @@ export class MenuItem {
        if (spec.shortcut) {
           const modKey = navigator.userAgent.indexOf('Mac') > 0 ? '⌘' : 'ctrl+';
           const shortcut = spec.shortcut;
-          title = `${title} <${modKey}${shortcut}>`;
+          title = `${title} (${modKey}${shortcut})`;
        }
 
        const tooltip = crel('div', {

--- a/src/menu.js
+++ b/src/menu.js
@@ -30,9 +30,9 @@ export class MenuItem {
        let title = (typeof spec.title === "function" ? spec.title(view.state) : spec.title)
 
        if (spec.shortcut) {
-          const modKey = navigator.userAgent.indexOf('Mac') > 0 ? '⌘' : 'ctrl';
+          const modKey = navigator.userAgent.indexOf('Mac') > 0 ? '⌘' : 'ctrl+';
           const shortcut = spec.shortcut;
-          title = `${title} (${modKey}+${shortcut})`;
+          title = `${title} <${modKey}${shortcut}>`;
        }
 
        const tooltip = crel('div', {

--- a/style/menu.css
+++ b/style/menu.css
@@ -154,17 +154,16 @@
     background-color: black;
     color: #fff;
     text-align: center;
-    padding: 5px 0;
+    padding: 5px 10px;
+    width: max-content;
     border-radius: 4px;
-    width: 180px;
     font-size: 16px;
     font-family: sans-serif;
 
     /* Position the tooltip text */
     position: absolute;
     bottom: 120%;
-    left: 50%;
-    margin-left: -90px;
+    left: -7px;
 }
 
 .ProseMirror-icon:hover .tooltiptext {
@@ -176,9 +175,9 @@
     content: " ";
     position: absolute;
     top: 100%; /* At the bottom of the tooltip */
-    left: 50%;
-    margin-left: -5px;
-    border-width: 5px;
+    left: 15px;
+    margin-left: -6px;
+    border-width: 6px;
     border-style: solid;
     border-color: black transparent transparent transparent;
 }

--- a/style/menu.css
+++ b/style/menu.css
@@ -155,7 +155,9 @@
     color: #fff;
     text-align: center;
     padding: 5px 10px;
-    width: max-content;
+    white-space: nowrap;
+    width: fit-content;
+    border-style: none;
     border-radius: 4px;
     font-size: 16px;
     font-family: sans-serif;


### PR DESCRIPTION
Couple minor tweaks:

1) Mac keyboard shortcuts will not show the '+' sign
2) Tooltips will be left justified over their corresponding icon instead of centered.
3) Also, they will have constant padding instead of constant width.

cr_req 1
qa_req smoketest

Closes #4