### PR TITLE
WYSIWYG Tooltips: Fix chopped off tooltips

### DIFF
--- a/style/menu.css
+++ b/style/menu.css
@@ -156,7 +156,6 @@
     text-align: center;
     padding: 5px 10px;
     white-space: nowrap;
-    width: fit-content;
     border-style: none;
     border-radius: 4px;
     font-size: 16px;


### PR DESCRIPTION
Fixes: https://github.com/iFixit/ifixit/issues/24797

If it fits it ships. cr_req 0

QA
---
1) Go to UI/templates/js/package.json
2) Replace the commit hash for prosemirror-menu with `c4845a960aadced9dbd4eeb8f9e3bf8fb84d47ef`
3) Run Exec/AssetBuild/install-app-npm-dep...
4) Please ensure tooltips look fine on Chome (mac/pc), Safari, IE, and Edge.